### PR TITLE
refactor more

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,0 @@
-# changelog
-
-## 0.1.0
-
-- publish
-  ([#19](https://github.com/ryanatkn/svelte-snake-sports/pull/21))

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,6 @@
+# changelog
+
+## 0.1.0
+
+- publish
+  ([#19](https://github.com/ryanatkn/svelte-snake-sports/pull/21))

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@feltcoop/eslint-config": "^0.2.1",
         "@feltcoop/felt": "^0.41.3",
-        "@feltcoop/gro": "^0.61.2",
+        "@feltcoop/gro": "^0.61.3",
         "@sveltejs/adapter-static": "^1.0.0-next.46",
         "@sveltejs/kit": "^1.0.0-next.522",
         "@typescript-eslint/eslint-plugin": "^5.40.1",
@@ -158,9 +158,9 @@
       }
     },
     "node_modules/@feltcoop/gro": {
-      "version": "0.61.2",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.61.2.tgz",
-      "integrity": "sha512-1zvdOS636p0FB+NnZJAD+MQRNcWBPlrsdxUizSk7Fi/PTK/GGptIIbMhCP+ncrAWG9OXuE5o/k3ao2ViI3dtnQ==",
+      "version": "0.61.3",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.61.3.tgz",
+      "integrity": "sha512-1P+NnCxfWl5WJ2NmHUG4j8yPYTvr5FhJ4wOPYCUtyZPr18xyurjVJIHzseKYGddkaAS8OF85va3EnauvhnIMWA==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^4.2.1",
@@ -424,9 +424,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.182",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
+      "version": "4.14.186",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
+      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -999,9 +999,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.0.3.tgz",
-      "integrity": "sha512-iC67eXHToclrlVhQfpRawDiF8D8sQxNxmbqw5oebegOaJkyx/w9C/k57/5e6yJR2zIByRt9OXdqX50DV2t6ZKw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.0.5.tgz",
+      "integrity": "sha512-oxJ+R1DzAw6j4g1Lx70bIKgfoRCX67C51kH2Mx7J4bS7ZzWxkcivXskFspzgKHUj6JUwUTghQgUPy8zTp6mMBw==",
       "dev": true
     },
     "node_modules/es6-promise": {
@@ -3312,9 +3312,9 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.61.2",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.61.2.tgz",
-      "integrity": "sha512-1zvdOS636p0FB+NnZJAD+MQRNcWBPlrsdxUizSk7Fi/PTK/GGptIIbMhCP+ncrAWG9OXuE5o/k3ao2ViI3dtnQ==",
+      "version": "0.61.3",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.61.3.tgz",
+      "integrity": "sha512-1P+NnCxfWl5WJ2NmHUG4j8yPYTvr5FhJ4wOPYCUtyZPr18xyurjVJIHzseKYGddkaAS8OF85va3EnauvhnIMWA==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^4.2.1",
@@ -3508,9 +3508,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.182",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
+      "version": "4.14.186",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
+      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==",
       "dev": true
     },
     "@types/node": {
@@ -3900,9 +3900,9 @@
       }
     },
     "es-module-lexer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.0.3.tgz",
-      "integrity": "sha512-iC67eXHToclrlVhQfpRawDiF8D8sQxNxmbqw5oebegOaJkyx/w9C/k57/5e6yJR2zIByRt9OXdqX50DV2t6ZKw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.0.5.tgz",
+      "integrity": "sha512-oxJ+R1DzAw6j4g1Lx70bIKgfoRCX67C51kH2Mx7J4bS7ZzWxkcivXskFspzgKHUj6JUwUTghQgUPy8zTp6mMBw==",
       "dev": true
     },
     "es6-promise": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@feltcoop/eslint-config": "^0.2.1",
     "@feltcoop/felt": "^0.41.3",
-    "@feltcoop/gro": "^0.61.2",
+    "@feltcoop/gro": "^0.61.3",
     "@sveltejs/adapter-static": "^1.0.0-next.46",
     "@sveltejs/kit": "^1.0.0-next.522",
     "@typescript-eslint/eslint-plugin": "^5.40.1",

--- a/src/lib/GameAudio.svelte
+++ b/src/lib/GameAudio.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import {base} from '$app/paths';
-
 	import Hotkeys from '$lib/Hotkeys.svelte';
 
 	export let song: string;
@@ -22,7 +20,7 @@
 	export const toggle = (): void => (playing ? pause() : play());
 </script>
 
-<audio src="{base}{song}" controls bind:this={el} />
+<audio src={song} controls bind:this={el} />
 
 <Hotkeys
 	onKeydown={(key, ctrlKey, altKey) => {

--- a/src/lib/ScaledSnakeRenderer.svelte
+++ b/src/lib/ScaledSnakeRenderer.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import {browser} from '$app/environment';
 	import {writable} from 'svelte/store';
 
 	import ScaledWorld from '$lib/ScaledWorld.svelte';
@@ -64,7 +63,7 @@
 	// Move `--bg_y` to the screen center of the renderer,
 	// so the vingette surrounds the game viewport.
 	$: bg_y = marginTop + screenHeight / 2;
-	$: if (browser) document.body.style.setProperty('--bg_y', bg_y + 'px');
+	$: document.body.style.setProperty('--bg_y', bg_y + 'px');
 </script>
 
 <ScaledWorld {screenWidth} {screenHeight} {worldWidth} {worldHeight}>

--- a/src/lib/Settings.svelte
+++ b/src/lib/Settings.svelte
@@ -36,8 +36,10 @@
 
 <form class="Settings">
 	<section>
-		<button type="button" title="[0] clear local storage" on:click={askToClearLocalStorage}
-			>reset saved data</button
+		<button
+			type="button"
+			title="[0] clear local storage"
+			on:click={() => askToClearLocalStorage(game.storageKey)}>reset saved data</button
 		>
 	</section>
 	<section>

--- a/src/lib/SnakeGame.svelte
+++ b/src/lib/SnakeGame.svelte
@@ -9,6 +9,8 @@
 	import {areOpposites, toDirection, type Direction} from '$lib/direction';
 
 	export let storageKey: string;
+	storageKey; // TODO disabling with eslint isn't working
+
 	export let toInitialState: () => SnakeGameState;
 	export let toInitialEvents: () => SnakeGameEvent[] = () => [];
 	export let toInitialMovementDirection: () => Direction | null = () => null;

--- a/src/lib/SnakeGame.svelte
+++ b/src/lib/SnakeGame.svelte
@@ -18,7 +18,6 @@
 
 	// this prop gets set by `beginUpdate`, but it's exposed for binding externally
 	export let prevState: SnakeGameState | undefined = undefined;
-	prevState; // TODO eslint borked
 
 	export const state = writable(toInitialState());
 	export const events = writable(toInitialEvents());

--- a/src/lib/SnakeGame.svelte
+++ b/src/lib/SnakeGame.svelte
@@ -8,6 +8,7 @@
 	import {spawnApples as _spawnApples} from '$lib/updateSnakeGameState';
 	import {areOpposites, toDirection, type Direction} from '$lib/direction';
 
+	export let storageKey: string;
 	export let toInitialState: () => SnakeGameState;
 	export let toInitialEvents: () => SnakeGameEvent[] = () => [];
 	export let toInitialMovementDirection: () => Direction | null = () => null;

--- a/src/lib/StageControls.svelte
+++ b/src/lib/StageControls.svelte
@@ -51,7 +51,7 @@
 				return true;
 			}
 			case '0': {
-				askToClearLocalStorage();
+				askToClearLocalStorage(game.storageKey);
 				return true;
 			}
 			case '3': {

--- a/src/lib/clock.ts
+++ b/src/lib/clock.ts
@@ -1,6 +1,5 @@
 import {writable, get, type Writable} from 'svelte/store';
 import {getContext, setContext} from 'svelte';
-import {browser} from '$app/environment';
 
 // TODO merge with `clock`
 
@@ -59,7 +58,6 @@ export const createClock = (initialState: Partial<ClockState> = {}): Clock => {
 		set,
 		update,
 		resume: (): void => {
-			if (!browser) return;
 			update(($clock) => {
 				if ($clock.running) return $clock;
 				queueUpdate();
@@ -67,7 +65,6 @@ export const createClock = (initialState: Partial<ClockState> = {}): Clock => {
 			});
 		},
 		pause: (): void => {
-			if (!browser) return;
 			update(($clock) => {
 				if (!$clock.running) return $clock;
 				cancelUpdate();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,19 @@
+export * from '$lib/clock';
+export * from '$lib/SnakeGameState';
+export * from '$lib/updateSnakeGameState';
+export * from '$lib/SnakeGame';
+export * from '$lib/Entity';
+
+export {default as SnakeGame} from '$lib/SnakeGame.svelte';
+export {default as Gamespace} from '$lib/Gamespace.svelte';
+export {default as DomRenderer} from '$lib/renderers/dom/DomRenderer.svelte';
+export {default as Settings} from '$lib/Settings.svelte';
+export {default as Score} from '$lib/Score.svelte';
+export {default as Stats} from '$lib/Stats.svelte';
+export {default as Ticker} from '$lib/Ticker.svelte';
+export {default as StageControls} from '$lib/StageControls.svelte';
+export {default as TextBurst} from '$lib/TextBurst.svelte';
+export {default as ScaledSnakeRenderer} from '$lib/ScaledSnakeRenderer.svelte';
+export {default as ControlsInstructions} from '$lib/ControlsInstructions.svelte';
+export {default as GameAudio} from '$lib/GameAudio.svelte';
+export {default as TimedScores} from '$lib/TimedScores.svelte';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,5 @@
 export * from '$lib/clock';
+export * from '$lib/storage';
 export * from '$lib/SnakeGameState';
 export * from '$lib/updateSnakeGameState';
 export * from '$lib/SnakeGame';

--- a/src/lib/sports/buncheses/BunchesesSnake.svelte
+++ b/src/lib/sports/buncheses/BunchesesSnake.svelte
@@ -27,11 +27,10 @@
 	import ScaledSnakeRenderer from '$lib/ScaledSnakeRenderer.svelte';
 	import {Entity} from '$lib/Entity';
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
-	import {registerStorageKey} from '$lib/storage';
 	import {setCurrentTickDuration} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
 
-	const BUNCHESES_HIGH_SCORE_KEY = registerStorageKey('buncheses_high_score');
+	const storageKey = 'buncheses_high_score';
 
 	export let game: SnakeGame | undefined = undefined;
 	export let audio: GameAudio | undefined = undefined;
@@ -66,7 +65,7 @@
 	let applesEaten = 0;
 	let bunchesEaten = 0;
 	const highestClustersEaten = writable<number>(
-		(browser && Number(localStorage.getItem(BUNCHESES_HIGH_SCORE_KEY))) || 0,
+		(browser && Number(localStorage.getItem(storageKey))) || 0,
 	);
 
 	const restart = (): void => {
@@ -89,7 +88,7 @@
 	// TODO is there a better place to do this? imperatively after updating the state?
 	$: if (bunchesEaten > $highestClustersEaten) {
 		$highestClustersEaten = bunchesEaten;
-		if (browser) localStorage.setItem(BUNCHESES_HIGH_SCORE_KEY, bunchesEaten + ''); // TODO use helper on store instead
+		if (browser) localStorage.setItem(storageKey, bunchesEaten + ''); // TODO use helper on store instead
 	}
 
 	const tick = (): boolean => {
@@ -154,6 +153,7 @@
 >
 	<SnakeGame
 		bind:this={game}
+		{storageKey}
 		toInitialMovementDirection={() => 'up'}
 		{tick}
 		onReset={() => {

--- a/src/lib/sports/buncheses/BunchesesSnake.svelte
+++ b/src/lib/sports/buncheses/BunchesesSnake.svelte
@@ -3,6 +3,7 @@
 	// https://ryanatkn.github.io/snake-game
 	// See `$lib/sports/simple/SimpleSnake.svelte` for the same thing but simplified.
 	import {writable, type Writable} from 'svelte/store';
+	import {base} from '$app/paths';
 
 	import SnakeGame from '$lib/SnakeGame.svelte';
 	import Gamespace from '$lib/Gamespace.svelte';
@@ -236,7 +237,7 @@
 						<a href="https://www.serpentsoundstudios.com/">Alexander Nakarada</a> -
 						<a href="/assets/Alexander_Nakarada__Lurking_Sloth.mp3">Lurking Sloth</a>
 					</p>
-					<GameAudio song="/assets/Alexander_Nakarada__Lurking_Sloth.mp3" bind:this={audio} />
+					<GameAudio song="{base}/assets/Alexander_Nakarada__Lurking_Sloth.mp3" bind:this={audio} />
 				</section>
 				<section class="centered">
 					<button on:click={() => (showSettings = !showSettings)}

--- a/src/lib/sports/buncheses/BunchesesSnake.svelte
+++ b/src/lib/sports/buncheses/BunchesesSnake.svelte
@@ -27,9 +27,11 @@
 	import ScaledSnakeRenderer from '$lib/ScaledSnakeRenderer.svelte';
 	import {Entity} from '$lib/Entity';
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
-	import {BUNCHESES_HIGH_SCORE_KEY} from '$lib/storage';
+	import {registerStorageKey} from '$lib/storage';
 	import {setCurrentTickDuration} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
+
+	const BUNCHESES_HIGH_SCORE_KEY = registerStorageKey('buncheses_high_score');
 
 	export let game: SnakeGame | undefined = undefined;
 	export let audio: GameAudio | undefined = undefined;

--- a/src/lib/sports/buncheses/BunchesesSnake.svelte
+++ b/src/lib/sports/buncheses/BunchesesSnake.svelte
@@ -2,7 +2,6 @@
 	// This version is a port of the original React project:
 	// https://ryanatkn.github.io/snake-game
 	// See `$lib/sports/simple/SimpleSnake.svelte` for the same thing but simplified.
-	import {browser} from '$app/environment';
 	import {writable, type Writable} from 'svelte/store';
 
 	import SnakeGame from '$lib/SnakeGame.svelte';
@@ -47,7 +46,7 @@
 		game.handlePointerInput(snakeX, snakeY, pointerX, pointerY);
 	}
 
-	const clock = setClock(createClock({running: browser}));
+	const clock = setClock(createClock({running: true}));
 
 	let showSettings = false;
 
@@ -64,9 +63,7 @@
 
 	let applesEaten = 0;
 	let bunchesEaten = 0;
-	const highestClustersEaten = writable<number>(
-		(browser && Number(localStorage.getItem(storageKey))) || 0,
-	);
+	const highestClustersEaten = writable<number>(Number(localStorage.getItem(storageKey)) || 0);
 
 	const restart = (): void => {
 		if (!game) return;
@@ -88,7 +85,7 @@
 	// TODO is there a better place to do this? imperatively after updating the state?
 	$: if (bunchesEaten > $highestClustersEaten) {
 		$highestClustersEaten = bunchesEaten;
-		if (browser) localStorage.setItem(storageKey, bunchesEaten + ''); // TODO use helper on store instead
+		localStorage.setItem(storageKey, bunchesEaten + ''); // TODO use helper on store instead
 	}
 
 	const tick = (): boolean => {

--- a/src/lib/sports/classsic/ClasssicSnake.svelte
+++ b/src/lib/sports/classsic/ClasssicSnake.svelte
@@ -21,11 +21,10 @@
 	import TextBurst from '$lib/TextBurst.svelte';
 	import ScaledSnakeRenderer from '$lib/ScaledSnakeRenderer.svelte';
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
-	import {registerStorageKey} from '$lib/storage';
 	import {setCurrentTickDuration} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
 
-	const CLASSSIC_HIGH_SCORE_KEY = registerStorageKey('classsic_high_score');
+	const storageKey = 'classsic_high_score';
 
 	export let game: SnakeGame | undefined = undefined;
 	export let audio: GameAudio | undefined = undefined;
@@ -57,7 +56,7 @@
 
 	let applesEaten = 0;
 	const highestApplesEaten = writable<number>(
-		(browser && Number(localStorage.getItem(CLASSSIC_HIGH_SCORE_KEY))) || 0,
+		(browser && Number(localStorage.getItem(storageKey))) || 0,
 	);
 
 	const restart = (): void => {
@@ -80,7 +79,7 @@
 	// TODO is there a better place to do this? imperatively after updating the state?
 	$: if (applesEaten > $highestApplesEaten) {
 		$highestApplesEaten = applesEaten;
-		if (browser) localStorage.setItem(CLASSSIC_HIGH_SCORE_KEY, applesEaten + ''); // TODO use helper on store instead
+		if (browser) localStorage.setItem(storageKey, applesEaten + ''); // TODO use helper on store instead
 	}
 
 	const tick = (): boolean => {
@@ -129,6 +128,7 @@
 >
 	<SnakeGame
 		bind:this={game}
+		{storageKey}
 		{toInitialState}
 		toInitialMovementDirection={() => 'up'}
 		{tick}

--- a/src/lib/sports/classsic/ClasssicSnake.svelte
+++ b/src/lib/sports/classsic/ClasssicSnake.svelte
@@ -2,7 +2,6 @@
 	// This version is a port of the original React project:
 	// https://ryanatkn.github.io/snake-game
 	// See `$lib/sports/simple/SimpleSnake.svelte` for the same thing but simplified.
-	import {browser} from '$app/environment';
 	import {writable, type Writable} from 'svelte/store';
 
 	import SnakeGame from '$lib/SnakeGame.svelte';
@@ -41,7 +40,7 @@
 		game.handlePointerInput(snakeX, snakeY, pointerX, pointerY);
 	}
 
-	const clock = setClock(createClock({running: browser}));
+	const clock = setClock(createClock({running: true}));
 
 	let showSettings = false;
 
@@ -55,9 +54,7 @@
 	$: if ($status === 'ready') $status = 'playing';
 
 	let applesEaten = 0;
-	const highestApplesEaten = writable<number>(
-		(browser && Number(localStorage.getItem(storageKey))) || 0,
-	);
+	const highestApplesEaten = writable<number>(Number(localStorage.getItem(storageKey)) || 0);
 
 	const restart = (): void => {
 		if (!game) return;
@@ -79,7 +76,7 @@
 	// TODO is there a better place to do this? imperatively after updating the state?
 	$: if (applesEaten > $highestApplesEaten) {
 		$highestApplesEaten = applesEaten;
-		if (browser) localStorage.setItem(storageKey, applesEaten + ''); // TODO use helper on store instead
+		localStorage.setItem(storageKey, applesEaten + ''); // TODO use helper on store instead
 	}
 
 	const tick = (): boolean => {

--- a/src/lib/sports/classsic/ClasssicSnake.svelte
+++ b/src/lib/sports/classsic/ClasssicSnake.svelte
@@ -21,9 +21,11 @@
 	import TextBurst from '$lib/TextBurst.svelte';
 	import ScaledSnakeRenderer from '$lib/ScaledSnakeRenderer.svelte';
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
-	import {CLASSSIC_HIGH_SCORE_KEY} from '$lib/storage';
+	import {registerStorageKey} from '$lib/storage';
 	import {setCurrentTickDuration} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
+
+	const CLASSSIC_HIGH_SCORE_KEY = registerStorageKey('classsic_high_score');
 
 	export let game: SnakeGame | undefined = undefined;
 	export let audio: GameAudio | undefined = undefined;

--- a/src/lib/sports/classsic/ClasssicSnake.svelte
+++ b/src/lib/sports/classsic/ClasssicSnake.svelte
@@ -3,6 +3,7 @@
 	// https://ryanatkn.github.io/snake-game
 	// See `$lib/sports/simple/SimpleSnake.svelte` for the same thing but simplified.
 	import {writable, type Writable} from 'svelte/store';
+	import {base} from '$app/paths';
 
 	import SnakeGame from '$lib/SnakeGame.svelte';
 	import Gamespace from '$lib/Gamespace.svelte';
@@ -172,7 +173,7 @@
 						<a href="https://www.serpentsoundstudios.com/">Alexander Nakarada</a> -
 						<a href="/assets/Alexander_Nakarada__Lurking_Sloth.mp3">Lurking Sloth</a>
 					</p>
-					<GameAudio song="/assets/Alexander_Nakarada__Lurking_Sloth.mp3" bind:this={audio} />
+					<GameAudio song="{base}/assets/Alexander_Nakarada__Lurking_Sloth.mp3" bind:this={audio} />
 				</section>
 				<section class="centered">
 					<button on:click={() => (showSettings = !showSettings)}

--- a/src/lib/sports/ssspeed/SsspeedSnake.svelte
+++ b/src/lib/sports/ssspeed/SsspeedSnake.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import {browser} from '$app/environment';
 	import {writable, type Writable} from 'svelte/store';
 
 	import SnakeGame from '$lib/SnakeGame.svelte';
@@ -23,7 +22,7 @@
 
 	const storageKey = 'ssspeed_high_score';
 
-	const clock = setClock(createClock({running: browser}));
+	const clock = setClock(createClock({running: true}));
 
 	export let game: SnakeGame | undefined = undefined;
 	export let audio: GameAudio | undefined = undefined;
@@ -72,9 +71,7 @@
 	let currentTime = 0;
 	$: if ($status === 'playing') currentTime += $clock.dt;
 
-	const bestTime = writable<number | null>(
-		(browser && Number(localStorage.getItem(storageKey))) || null,
-	);
+	const bestTime = writable<number | null>(Number(localStorage.getItem(storageKey)) || null);
 
 	const tick = (): boolean => {
 		if (!game || !$state || !$events || $status !== 'playing') {
@@ -109,7 +106,7 @@
 			// don't set the high score immediately like this, wait til it's over
 			if (!$bestTime || currentTime < $bestTime) {
 				$bestTime = Math.round(currentTime);
-				if (browser) localStorage.setItem(storageKey, $bestTime + ''); // TODO use helper on store instead
+				localStorage.setItem(storageKey, $bestTime + ''); // TODO use helper on store instead
 			}
 		}
 

--- a/src/lib/sports/ssspeed/SsspeedSnake.svelte
+++ b/src/lib/sports/ssspeed/SsspeedSnake.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import {writable, type Writable} from 'svelte/store';
+	import {base} from '$app/paths';
 
 	import SnakeGame from '$lib/SnakeGame.svelte';
 	import Gamespace from '$lib/Gamespace.svelte';
@@ -181,7 +182,7 @@
 						<a href="https://www.serpentsoundstudios.com/">Alexander Nakarada</a> -
 						<a href="/assets/Alexander_Nakarada__Lurking_Sloth.mp3">Lurking Sloth</a>
 					</p>
-					<GameAudio song="/assets/Alexander_Nakarada__Lurking_Sloth.mp3" bind:this={audio} />
+					<GameAudio song="{base}/assets/Alexander_Nakarada__Lurking_Sloth.mp3" bind:this={audio} />
 				</section>
 				<section class="centered">
 					<button on:click={() => (showSettings = !showSettings)}

--- a/src/lib/sports/ssspeed/SsspeedSnake.svelte
+++ b/src/lib/sports/ssspeed/SsspeedSnake.svelte
@@ -22,7 +22,6 @@
 	import {setCurrentTickDuration} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
 
-	// TODO BLOCK does this need to be in the module context? does that ensure it runs?
 	const SSSPEED_HIGH_SCORE_KEY = registerStorageKey('ssspeed_high_score');
 
 	const clock = setClock(createClock({running: browser}));

--- a/src/lib/sports/ssspeed/SsspeedSnake.svelte
+++ b/src/lib/sports/ssspeed/SsspeedSnake.svelte
@@ -18,9 +18,12 @@
 	import TextBurst from '$lib/TextBurst.svelte';
 	import ScaledSnakeRenderer from '$lib/ScaledSnakeRenderer.svelte';
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
-	import {SSSPEED_HIGH_SCORE_KEY} from '$lib/storage';
+	import {registerStorageKey} from '$lib/storage';
 	import {setCurrentTickDuration} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
+
+	// TODO BLOCK does this need to be in the module context? does that ensure it runs?
+	const SSSPEED_HIGH_SCORE_KEY = registerStorageKey('ssspeed_high_score');
 
 	const clock = setClock(createClock({running: browser}));
 

--- a/src/lib/sports/ssspeed/SsspeedSnake.svelte
+++ b/src/lib/sports/ssspeed/SsspeedSnake.svelte
@@ -18,11 +18,10 @@
 	import TextBurst from '$lib/TextBurst.svelte';
 	import ScaledSnakeRenderer from '$lib/ScaledSnakeRenderer.svelte';
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
-	import {registerStorageKey} from '$lib/storage';
 	import {setCurrentTickDuration} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
 
-	const SSSPEED_HIGH_SCORE_KEY = registerStorageKey('ssspeed_high_score');
+	const storageKey = 'ssspeed_high_score';
 
 	const clock = setClock(createClock({running: browser}));
 
@@ -74,7 +73,7 @@
 	$: if ($status === 'playing') currentTime += $clock.dt;
 
 	const bestTime = writable<number | null>(
-		(browser && Number(localStorage.getItem(SSSPEED_HIGH_SCORE_KEY))) || null,
+		(browser && Number(localStorage.getItem(storageKey))) || null,
 	);
 
 	const tick = (): boolean => {
@@ -110,7 +109,7 @@
 			// don't set the high score immediately like this, wait til it's over
 			if (!$bestTime || currentTime < $bestTime) {
 				$bestTime = Math.round(currentTime);
-				if (browser) localStorage.setItem(SSSPEED_HIGH_SCORE_KEY, $bestTime + ''); // TODO use helper on store instead
+				if (browser) localStorage.setItem(storageKey, $bestTime + ''); // TODO use helper on store instead
 			}
 		}
 
@@ -121,6 +120,7 @@
 <div class="SsspeedSnake" class:game-win={$status === 'win'} class:game-ready={$status === 'ready'}>
 	<SnakeGame
 		bind:this={game}
+		{storageKey}
 		toInitialState={() => initGameState(toDefaultGameState({mapWidth, mapHeight}))}
 		{tick}
 		onReset={() => {

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -18,11 +18,10 @@
 	import TextBurst from '$lib/TextBurst.svelte';
 	import ScaledSnakeRenderer from '$lib/ScaledSnakeRenderer.svelte';
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
-	import {registerStorageKey} from '$lib/storage';
 	import {setCurrentTickDuration, type ISnakeGame} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
 
-	const TRAILSSS_HIGH_SCORE_KEY = registerStorageKey('trailsss_high_score');
+	const storageKey = 'trailsss_high_score';
 
 	const clock = setClock(createClock({running: browser}));
 
@@ -74,7 +73,7 @@
 	$: if ($status === 'playing') currentTime += $clock.dt;
 
 	const bestTime = writable<number | null>(
-		(browser && Number(localStorage.getItem(TRAILSSS_HIGH_SCORE_KEY))) || null,
+		(browser && Number(localStorage.getItem(storageKey))) || null,
 	);
 
 	const tick = (): boolean => {
@@ -109,7 +108,7 @@
 			// don't set the high score immediately like this, wait til it's over
 			if (!$bestTime || currentTime < $bestTime) {
 				$bestTime = Math.round(currentTime);
-				if (browser) localStorage.setItem(TRAILSSS_HIGH_SCORE_KEY, $bestTime + ''); // TODO use helper on store instead
+				if (browser) localStorage.setItem(storageKey, $bestTime + ''); // TODO use helper on store instead
 			}
 		}
 
@@ -145,6 +144,7 @@
 >
 	<SnakeGame
 		bind:this={game}
+		{storageKey}
 		{tick}
 		onReset={() => {
 			$currentTickDuration = $baseTickDuration;

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import {writable, type Writable} from 'svelte/store';
+	import {base} from '$app/paths';
 
 	import SnakeGame from '$lib/SnakeGame.svelte';
 	import Gamespace from '$lib/Gamespace.svelte';
@@ -207,7 +208,10 @@
 						<a href="https://www.serpentsoundstudios.com/">Alexander Nakarada</a> -
 						<a href="/assets/Alexander_Nakarada__Horde_of_Geese.mp3">Horde of Geese</a>
 					</p>
-					<GameAudio song="/assets/Alexander_Nakarada__Horde_of_Geese.mp3" bind:this={audio} />
+					<GameAudio
+						song="{base}/assets/Alexander_Nakarada__Horde_of_Geese.mp3"
+						bind:this={audio}
+					/>
 				</section>
 				<section class="centered">
 					<button on:click={() => (showSettings = !showSettings)}

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -18,7 +18,7 @@
 	import TextBurst from '$lib/TextBurst.svelte';
 	import ScaledSnakeRenderer from '$lib/ScaledSnakeRenderer.svelte';
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
-	import {SSSPEED_HIGH_SCORE_KEY} from '$lib/storage';
+	import {TRAILSSS_HIGH_SCORE_KEY} from '$lib/storage';
 	import {setCurrentTickDuration, type ISnakeGame} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
 
@@ -72,7 +72,7 @@
 	$: if ($status === 'playing') currentTime += $clock.dt;
 
 	const bestTime = writable<number | null>(
-		(browser && Number(localStorage.getItem(SSSPEED_HIGH_SCORE_KEY))) || null,
+		(browser && Number(localStorage.getItem(TRAILSSS_HIGH_SCORE_KEY))) || null,
 	);
 
 	const tick = (): boolean => {
@@ -107,7 +107,7 @@
 			// don't set the high score immediately like this, wait til it's over
 			if (!$bestTime || currentTime < $bestTime) {
 				$bestTime = Math.round(currentTime);
-				if (browser) localStorage.setItem(SSSPEED_HIGH_SCORE_KEY, $bestTime + ''); // TODO use helper on store instead
+				if (browser) localStorage.setItem(TRAILSSS_HIGH_SCORE_KEY, $bestTime + ''); // TODO use helper on store instead
 			}
 		}
 

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -18,9 +18,11 @@
 	import TextBurst from '$lib/TextBurst.svelte';
 	import ScaledSnakeRenderer from '$lib/ScaledSnakeRenderer.svelte';
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
-	import {TRAILSSS_HIGH_SCORE_KEY} from '$lib/storage';
+	import {registerStorageKey} from '$lib/storage';
 	import {setCurrentTickDuration, type ISnakeGame} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
+
+	const TRAILSSS_HIGH_SCORE_KEY = registerStorageKey('trailsss_high_score');
 
 	const clock = setClock(createClock({running: browser}));
 

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import {browser} from '$app/environment';
 	import {writable, type Writable} from 'svelte/store';
 
 	import SnakeGame from '$lib/SnakeGame.svelte';
@@ -23,7 +22,7 @@
 
 	const storageKey = 'trailsss_high_score';
 
-	const clock = setClock(createClock({running: browser}));
+	const clock = setClock(createClock({running: true}));
 
 	export let game: SnakeGame | undefined = undefined;
 	export let audio: GameAudio | undefined = undefined;
@@ -72,9 +71,7 @@
 	let currentTime = 0;
 	$: if ($status === 'playing') currentTime += $clock.dt;
 
-	const bestTime = writable<number | null>(
-		(browser && Number(localStorage.getItem(storageKey))) || null,
-	);
+	const bestTime = writable<number | null>(Number(localStorage.getItem(storageKey)) || null);
 
 	const tick = (): boolean => {
 		if (!game || !$state || !$events || $status !== 'playing') {
@@ -108,7 +105,7 @@
 			// don't set the high score immediately like this, wait til it's over
 			if (!$bestTime || currentTime < $bestTime) {
 				$bestTime = Math.round(currentTime);
-				if (browser) localStorage.setItem(storageKey, $bestTime + ''); // TODO use helper on store instead
+				localStorage.setItem(storageKey, $bestTime + ''); // TODO use helper on store instead
 			}
 		}
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,24 +1,15 @@
 import {browser} from '$app/environment';
 
-const storageKeys = new Set<string>();
-
-export const registerStorageKey = <T extends string>(key: T): T => {
-	storageKeys.add(key);
-	return key;
-};
-
-export const clearLocalStorage = (): void => {
+export const clearLocalStorage = (key: string): void => {
 	if (!browser) return;
-	for (const key of storageKeys) {
-		localStorage.removeItem(key);
-	}
+	localStorage.removeItem(key);
 	window.location = window.location;
 };
 
-export const askToClearLocalStorage = (): void => {
+export const askToClearLocalStorage = (key: string): void => {
 	if (!browser) return;
 	// eslint-disable-next-line no-alert
 	if (confirm('permanently delete all saved data?')) {
-		clearLocalStorage();
+		clearLocalStorage(key);
 	}
 };

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,6 +1,6 @@
 import {browser} from '$app/environment';
 
-// TODO BLOCK maybe use `locallyStored` or export a `createStorage` function,
+// TODO maybe use `locallyStored` or export a `createStorage` function,
 // returning a store instance that gets saved automatically, abstracting away the key
 
 export const clearLocalStorage = (key: string): void => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,16 +1,12 @@
-import {browser} from '$app/environment';
-
 // TODO maybe use `locallyStored` or export a `createStorage` function,
 // returning a store instance that gets saved automatically, abstracting away the key
 
 export const clearLocalStorage = (key: string): void => {
-	if (!browser) return;
 	localStorage.removeItem(key);
 	window.location = window.location; // TODO hacky until this is a store
 };
 
 export const askToClearLocalStorage = (key: string): void => {
-	if (!browser) return;
 	// eslint-disable-next-line no-alert
 	if (confirm('permanently delete all saved data?')) {
 		clearLocalStorage(key);

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,17 +1,17 @@
 import {browser} from '$app/environment';
 
-// TODO BLOCK make this extensible
-export const CLASSSIC_HIGH_SCORE_KEY = 'classsic_high_score';
-export const SSSPEED_HIGH_SCORE_KEY = 'ssspeed_high_score';
-export const BUNCHESES_HIGH_SCORE_KEY = 'buncheses_high_score';
-export const TRAILSSS_HIGH_SCORE_KEY = 'trailsss_high_score';
+const storageKeys = new Set<string>();
+
+export const registerStorageKey = <T extends string>(key: T): T => {
+	storageKeys.add(key);
+	return key;
+};
 
 export const clearLocalStorage = (): void => {
 	if (!browser) return;
-	localStorage.removeItem(CLASSSIC_HIGH_SCORE_KEY);
-	localStorage.removeItem(SSSPEED_HIGH_SCORE_KEY);
-	localStorage.removeItem(BUNCHESES_HIGH_SCORE_KEY);
-	localStorage.removeItem(TRAILSSS_HIGH_SCORE_KEY);
+	for (const key of storageKeys) {
+		localStorage.removeItem(key);
+	}
 	window.location = window.location;
 };
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -6,7 +6,7 @@ import {browser} from '$app/environment';
 export const clearLocalStorage = (key: string): void => {
 	if (!browser) return;
 	localStorage.removeItem(key);
-	window.location = window.location;
+	window.location = window.location; // TODO hacky until this is a store
 };
 
 export const askToClearLocalStorage = (key: string): void => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,5 +1,8 @@
 import {browser} from '$app/environment';
 
+// TODO BLOCK maybe use `locallyStored` or export a `createStorage` function,
+// returning a store instance that gets saved automatically, abstracting away the key
+
 export const clearLocalStorage = (key: string): void => {
 	if (!browser) return;
 	localStorage.removeItem(key);

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,14 +1,17 @@
 import {browser} from '$app/environment';
 
+// TODO BLOCK make this extensible
 export const CLASSSIC_HIGH_SCORE_KEY = 'classsic_high_score';
 export const SSSPEED_HIGH_SCORE_KEY = 'ssspeed_high_score';
 export const BUNCHESES_HIGH_SCORE_KEY = 'buncheses_high_score';
+export const TRAILSSS_HIGH_SCORE_KEY = 'trailsss_high_score';
 
 export const clearLocalStorage = (): void => {
 	if (!browser) return;
 	localStorage.removeItem(CLASSSIC_HIGH_SCORE_KEY);
 	localStorage.removeItem(SSSPEED_HIGH_SCORE_KEY);
 	localStorage.removeItem(BUNCHESES_HIGH_SCORE_KEY);
+	localStorage.removeItem(TRAILSSS_HIGH_SCORE_KEY);
 	window.location = window.location;
 };
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,1 +1,2 @@
 export const prerender = true;
+export const ssr = false;


### PR DESCRIPTION
In preparation for making a library that's usable from the Svelte REPL, this adds a `src/lib/index.ts` with the exported files, and 

The big blocker to making it REPL-friendly is the TypeScript Svelte files. See this issue: https://github.com/sveltejs/sites/issues /156

There seem to be a few options:

- wait for TS support (or contribute to learn.svelte.dev)
- change Gro to interpret `types: false` as stripping types from Svelte files on build
- change this codebase from TS to JS with TS comments