### PR TITLE
refactor and publish dimensions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.2.0
+
+- **break**: refactor and publish `Dimensions.svelte`
+  ([#24](https://github.com/feltcoop/felt/pull/24))
+
 ## 0.1.1
 
 - use `console.log` instead of Felt logger

--- a/src/lib/Dimensions.svelte
+++ b/src/lib/Dimensions.svelte
@@ -1,22 +1,7 @@
-<script lang="ts" context="module">
-	import {getContext, setContext} from 'svelte';
+<script lang="ts">
 	import type {Writable} from 'svelte/store';
 
-	export interface Dimensions {
-		width: number;
-		height: number;
-	}
-
-	const KEY = Symbol();
-
-	export const getDimensions = (): Writable<Dimensions> => getContext(KEY);
-
-	export const setDimensions = (dimensions: Writable<Dimensions>): Writable<Dimensions> =>
-		setContext(KEY, dimensions);
-</script>
-
-<script lang="ts">
-	export let dimensions: Writable<Dimensions>;
+	export let dimensions: Writable<{width: number; height: number}>;
 
 	// This measures an onscreen element instead of window.innerWidth/Height
 	// to account for scrollbars on some OSes.

--- a/src/lib/ScaledSnakeRenderer.svelte
+++ b/src/lib/ScaledSnakeRenderer.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import {writable} from 'svelte/store';
+	import {writable, type Writable} from 'svelte/store';
 
 	import ScaledWorld from '$lib/ScaledWorld.svelte';
-	import {getDimensions} from '$lib/Dimensions.svelte';
 
+	export let dimensions: Writable<{width: number; height: number}>;
 	export let marginX = 32;
 	export let marginTop = 400; // TODO the 400 is the height of the `TitleImage`
 	export let marginBottom = 83; // TODO the 83 is the height of the `.scores` minus the paddingY
@@ -15,7 +15,6 @@
 	export const autoAspectRatio = writable(false);
 	export const aspectRatio = writable(1.0);
 
-	const dimensions = getDimensions();
 	$: availableWidth = Math.max(0, $dimensions.width - marginX);
 	$: availableHeight = Math.max(0, $dimensions.height - marginTop - marginBottom);
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -15,6 +15,8 @@ export {default as Ticker} from '$lib/Ticker.svelte';
 export {default as StageControls} from '$lib/StageControls.svelte';
 export {default as TextBurst} from '$lib/TextBurst.svelte';
 export {default as ScaledSnakeRenderer} from '$lib/ScaledSnakeRenderer.svelte';
+export {default as Dimensions} from '$lib/Dimensions.svelte';
 export {default as ControlsInstructions} from '$lib/ControlsInstructions.svelte';
+export {default as RestartInstructions} from '$lib/RestartInstructions.svelte';
 export {default as GameAudio} from '$lib/GameAudio.svelte';
 export {default as TimedScores} from '$lib/TimedScores.svelte';

--- a/src/lib/sports/buncheses/BunchesesSnake.svelte
+++ b/src/lib/sports/buncheses/BunchesesSnake.svelte
@@ -29,8 +29,11 @@
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
 	import {setCurrentTickDuration} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
+	import Dimensions from '$lib/Dimensions.svelte';
 
 	const storageKey = 'buncheses_high_score';
+	const clock = setClock(createClock({running: true}));
+	const dimensions = writable({width: 0, height: 0});
 
 	export let game: SnakeGame | undefined = undefined;
 	export let audio: GameAudio | undefined = undefined;
@@ -46,8 +49,6 @@
 	$: if (game && pointerDown && pointerX !== undefined && pointerY !== undefined) {
 		game.handlePointerInput(snakeX, snakeY, pointerX, pointerY);
 	}
-
-	const clock = setClock(createClock({running: true}));
 
 	let showSettings = false;
 
@@ -144,6 +145,8 @@
 	const MAX_SPAWN_ATTEMPTS = 30; // TODO where does this belong?
 </script>
 
+<Dimensions {dimensions} />
+
 <div
 	class="ClasssicSnake"
 	class:game-fail={$status === 'fail'}
@@ -194,7 +197,13 @@
 	/>
 	{#if game}
 		<Gamespace bind:pointerDown bind:pointerX bind:pointerY>
-			<ScaledSnakeRenderer bind:autoAspectRatio bind:aspectRatio let:worldWidth let:worldHeight>
+			<ScaledSnakeRenderer
+				{dimensions}
+				bind:autoAspectRatio
+				bind:aspectRatio
+				let:worldWidth
+				let:worldHeight
+			>
 				<DomRenderer {game} width={worldWidth} height={worldHeight} bind:snakeX bind:snakeY />
 			</ScaledSnakeRenderer>
 			<svelte:fragment slot="overlay">

--- a/src/lib/sports/classsic/ClasssicSnake.svelte
+++ b/src/lib/sports/classsic/ClasssicSnake.svelte
@@ -23,8 +23,11 @@
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
 	import {setCurrentTickDuration} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
+	import Dimensions from '$lib/Dimensions.svelte';
 
 	const storageKey = 'classsic_high_score';
+	const clock = setClock(createClock({running: true}));
+	const dimensions = writable({width: 0, height: 0});
 
 	export let game: SnakeGame | undefined = undefined;
 	export let audio: GameAudio | undefined = undefined;
@@ -40,8 +43,6 @@
 	$: if (game && pointerDown && pointerX !== undefined && pointerY !== undefined) {
 		game.handlePointerInput(snakeX, snakeY, pointerX, pointerY);
 	}
-
-	const clock = setClock(createClock({running: true}));
 
 	let showSettings = false;
 
@@ -119,6 +120,8 @@
 	};
 </script>
 
+<Dimensions {dimensions} />
+
 <div
 	class="ClasssicSnake"
 	class:game-fail={$status === 'fail'}
@@ -137,7 +140,13 @@
 	/>
 	{#if game}
 		<Gamespace bind:pointerDown bind:pointerX bind:pointerY>
-			<ScaledSnakeRenderer bind:autoAspectRatio bind:aspectRatio let:worldWidth let:worldHeight>
+			<ScaledSnakeRenderer
+				{dimensions}
+				bind:autoAspectRatio
+				bind:aspectRatio
+				let:worldWidth
+				let:worldHeight
+			>
 				<DomRenderer {game} width={worldWidth} height={worldHeight} bind:snakeX bind:snakeY />
 			</ScaledSnakeRenderer>
 			<svelte:fragment slot="overlay">

--- a/src/lib/sports/ssspeed/SsspeedSnake.svelte
+++ b/src/lib/sports/ssspeed/SsspeedSnake.svelte
@@ -20,10 +20,11 @@
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
 	import {setCurrentTickDuration} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
+	import Dimensions from '$lib/Dimensions.svelte';
 
 	const storageKey = 'ssspeed_high_score';
-
 	const clock = setClock(createClock({running: true}));
+	const dimensions = writable({width: 0, height: 0});
 
 	export let game: SnakeGame | undefined = undefined;
 	export let audio: GameAudio | undefined = undefined;
@@ -115,6 +116,8 @@
 	};
 </script>
 
+<Dimensions {dimensions} />
+
 <div class="SsspeedSnake" class:game-win={$status === 'win'} class:game-ready={$status === 'ready'}>
 	<SnakeGame
 		bind:this={game}
@@ -137,6 +140,7 @@
 		<Gamespace bind:pointerDown bind:pointerX bind:pointerY>
 			<!-- TODO `marginBottom={100}` is hardcoding the scores height -->
 			<ScaledSnakeRenderer
+				{dimensions}
 				marginBottom={100}
 				bind:rendererWidth
 				bind:autoAspectRatio

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -20,10 +20,11 @@
 	import ControlsInstructions from '$lib/ControlsInstructions.svelte';
 	import {setCurrentTickDuration, type ISnakeGame} from '$lib/SnakeGame';
 	import GameAudio from '$lib/GameAudio.svelte';
+	import Dimensions from '$lib/Dimensions.svelte';
 
 	const storageKey = 'trailsss_high_score';
-
 	const clock = setClock(createClock({running: true}));
+	const dimensions = writable({width: 0, height: 0});
 
 	export let game: SnakeGame | undefined = undefined;
 	export let audio: GameAudio | undefined = undefined;
@@ -135,6 +136,8 @@
 	};
 </script>
 
+<Dimensions {dimensions} />
+
 <div
 	class="TrailsssSnake"
 	class:game-win={$status === 'win'}
@@ -163,6 +166,7 @@
 		<Gamespace bind:pointerDown bind:pointerX bind:pointerY>
 			<!-- TODO `marginBottom={100}` is hardcoding the scores height -->
 			<ScaledSnakeRenderer
+				{dimensions}
 				marginBottom={100}
 				bind:rendererWidth
 				bind:autoAspectRatio

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,19 +1,13 @@
 <script lang="ts">
 	import '@feltcoop/felt/ui/style.css';
 	import {base} from '$app/paths';
-	import {writable} from 'svelte/store';
 
 	import '$lib/style.css';
-	import Dimensions, {setDimensions} from '$lib/Dimensions.svelte';
-
-	const dimensions = setDimensions(writable({width: 0, height: 0}));
 </script>
 
 <svelte:head>
 	<title>svelte-snake-sports</title>
 	<link rel="icon" href="{base}/favicon.png" />
 </svelte:head>
-
-<Dimensions {dimensions} />
 
 <slot />


### PR DESCRIPTION
Refactors `Dimensions.svelte` and makes the renderer take `dimensions` as a prop instead of pulling it from context. 

Also publishes `RestartInstructions.svelte`.