### PR TITLE
improve visual feedback for InteractiveSurface.svelte

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.2.3
+
+- improve visual feedback for `InteractiveSurface.svelte`
+  ([#27](https://github.com/feltcoop/felt/pull/27))
+
 ## 0.2.2
 
 - use `localStorage` helpers wrapped in try/catch

--- a/src/lib/Gamespace.svelte
+++ b/src/lib/Gamespace.svelte
@@ -16,6 +16,7 @@
 	<slot />
 	<div class="interactive-surface-wrapper">
 		<InteractiveSurface
+			{pointerDown}
 			setPointerDown={(down) => {
 				pointerDown = down;
 			}}

--- a/src/lib/InteractiveSurface.svelte
+++ b/src/lib/InteractiveSurface.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import {swallow} from '@feltcoop/felt/util/dom.js';
+	import {onMount} from 'svelte';
 
 	// TODO maybe use pointer events?
 	// https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events
 
+	export let pointerDown: boolean; // readonly (but maybe remove `setPointerDown`?)
 	export let setPointerDown: (down: boolean) => void;
 	export let setPointerPosition: (x: number, y: number) => void;
 
@@ -16,6 +18,7 @@
 		swallow(e);
 		updatePointer(e.offsetX, e.offsetY);
 		setPointerDown(true);
+		focus();
 	};
 	const onMouseup = (e: MouseEvent) => {
 		if (e.button >= 3) return; // TODO how else to avoid breaking mouse back button on Chrome? doesn't happen on Firefox
@@ -35,6 +38,7 @@
 		swallow(e);
 		updatePointer(e.offsetX, e.offsetY);
 		setPointerDown(false);
+		if (pointerDown) unfocus(); // TODO equivalent for touch?
 	};
 
 	let touch = false;
@@ -47,6 +51,7 @@
 		const rect = (e.target as HTMLElement).getBoundingClientRect();
 		updatePointer(e.changedTouches[0].pageX - rect.left, e.changedTouches[0].pageY - rect.top);
 		setPointerDown(true);
+		focus();
 	};
 	const onTouchend = (e: TouchEvent) => {
 		swallow(e);
@@ -74,10 +79,30 @@
 			swallow(e);
 		}
 	};
+
+	let el: HTMLDivElement;
+
+	const focus = () => {
+		if (document.activeElement !== el) {
+			el.focus();
+		}
+	};
+	const unfocus = () => {
+		if (document.activeElement === el) {
+			el.blur();
+		}
+	};
+
+	onMount(() => {
+		focus();
+	});
 </script>
 
 <div
 	class="interactive-surface"
+	tabindex="0"
+	role="button"
+	bind:this={el}
 	on:mousedown={onMousedown}
 	on:mouseup={onMouseup}
 	on:mousemove={onMousemove}
@@ -95,5 +120,9 @@
 		position: absolute;
 		inset: 0;
 		user-select: none;
+	}
+	.interactive-surface:focus {
+		outline: var(--border_width_5) dotted var(--border_color_dark);
+		border-radius: var(--border_radius_xs);
 	}
 </style>

--- a/src/lib/InteractiveSurface.svelte
+++ b/src/lib/InteractiveSurface.svelte
@@ -79,12 +79,12 @@
 
 	let el: HTMLDivElement;
 
-	const focus = () => {
+	const focus = (): void => {
 		if (document.activeElement !== el) {
 			el.focus();
 		}
 	};
-	const unfocus = () => {
+	const unfocus = (): void => {
 		if (document.activeElement === el) {
 			el.blur();
 		}

--- a/src/lib/InteractiveSurface.svelte
+++ b/src/lib/InteractiveSurface.svelte
@@ -2,10 +2,7 @@
 	import {swallow} from '@feltcoop/felt/util/dom.js';
 	import {onMount} from 'svelte';
 
-	// TODO maybe use pointer events?
-	// https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events
-
-	export let pointerDown: boolean; // readonly (but maybe remove `setPointerDown`?)
+	export let pointerDown: boolean; // readonly -- but maybe remove `setPointerDown` and bind to it externally?
 	export let setPointerDown: (down: boolean) => void;
 	export let setPointerPosition: (x: number, y: number) => void;
 


### PR DESCRIPTION
Makes the `InteractiveSurface` more interactive, giving it `tabindex="0"` and focus styling. I added `role="button"` to silence a11y but there may be a better role, couldn't find one.

references:

- https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-tabindex.md
- https://github.com/sveltejs/svelte/issues/ 7953