### PR TITLE
improve highscores for trailsss

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # changelog
 
+## 0.3.0
+
+- change `TimeScores` prop `bestTime` to no longer have a store wrapper
+  ([#28](https://github.com/feltcoop/felt/pull/28))
+
 ## 0.2.4
 
 - remove `InteractiveSurface.svelte` focus on mount

--- a/src/lib/EatenOrTimedScores.svelte
+++ b/src/lib/EatenOrTimedScores.svelte
@@ -14,7 +14,7 @@
 	export let rendererWidth: Writable<number>;
 
 	let winType: 'time' | 'applesEaten';
-	$: winType = applesEaten > applesToWin ? 'applesEaten' : 'time';
+	$: winType = highestApplesEaten || applesEaten > applesToWin ? 'applesEaten' : 'time';
 </script>
 
 {#if winType === 'applesEaten'}

--- a/src/lib/EatenOrTimedScores.svelte
+++ b/src/lib/EatenOrTimedScores.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type {Writable} from 'svelte/store';
+
+	import TimedScores from '$lib/TimedScores.svelte';
+	import EatenScores from '$lib/EatenScores.svelte';
+
+	// TODO rename this module
+
+	export let applesEaten: number;
+	export let highestApplesEaten: number | null;
+	export let applesToWin: number;
+	export let currentTime: number;
+	export let bestTime: number | null;
+	export let rendererWidth: Writable<number>;
+
+	let winType: 'time' | 'applesEaten';
+	$: winType = applesEaten > applesToWin ? 'applesEaten' : 'time';
+</script>
+
+{#if winType === 'applesEaten'}
+	<EatenScores {applesEaten} {highestApplesEaten} />
+{:else}
+	<TimedScores {applesEaten} {applesToWin} {currentTime} {bestTime} {rendererWidth} />
+{/if}

--- a/src/lib/EatenScores.svelte
+++ b/src/lib/EatenScores.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import Score from '$lib/Score.svelte';
+
+	export let applesEaten: number;
+	export let highestApplesEaten: number | null;
+</script>
+
+<Score title="apples eaten this try" progressKey={applesEaten === 0 ? undefined : applesEaten}
+	>{applesEaten}</Score
+>
+{#if highestApplesEaten && highestApplesEaten !== applesEaten}
+	<Score title="the most apples you've ever eaten">{highestApplesEaten}</Score>
+{/if}

--- a/src/lib/TimedScores.svelte
+++ b/src/lib/TimedScores.svelte
@@ -50,7 +50,7 @@
 			</div>
 		{/each}
 	</div>
-	<div class="time-and-score">
+	<div class="centered-hz">
 		<div
 			class="time"
 			title="{currentTimeSeconds} second{currentTimeSeconds === 1 ? ' has' : 's have'} elapsed"

--- a/src/lib/TimedScores.svelte
+++ b/src/lib/TimedScores.svelte
@@ -81,11 +81,6 @@
 		width: calc(var(--map_width) * 1px);
 	}
 
-	.time-and-score {
-		display: flex;
-		align-items: center;
-	}
-
 	.count {
 		display: flex;
 		align-items: center;

--- a/src/lib/TimedScores.svelte
+++ b/src/lib/TimedScores.svelte
@@ -8,7 +8,7 @@
 	export let applesEaten: number;
 	export let applesToWin: number;
 	export let currentTime: number;
-	export let bestTime: Writable<number | null>;
+	export let bestTime: number | null;
 	export let rendererWidth: Writable<number>;
 
 	const APPLE_SIZE = 16;
@@ -34,8 +34,8 @@
 	});
 
 	$: currentTimeSeconds = Math.floor(currentTime / 1000);
-	$: bestTimeSeconds = $bestTime !== null ? Math.floor($bestTime / 1000) : null;
-	$: bestTimeMs = $bestTime !== null ? Math.round($bestTime) : null;
+	$: bestTimeSeconds = bestTime !== null ? Math.floor(bestTime / 1000) : null;
+	$: bestTimeMs = bestTime !== null ? Math.round(bestTime) : null;
 </script>
 
 <div class="progress">

--- a/src/lib/sports/ssspeed/SsspeedSnake.svelte
+++ b/src/lib/sports/ssspeed/SsspeedSnake.svelte
@@ -175,7 +175,7 @@
 					{applesEaten}
 					applesToWin={APPLES_EATEN_TO_WIN}
 					{currentTime}
-					{bestTime}
+					bestTime={$bestTime}
 					{rendererWidth}
 				/>
 				<StageControls {clock} {tick} {game} />

--- a/src/lib/sports/trailsss/ReadyInstructions.svelte
+++ b/src/lib/sports/trailsss/ReadyInstructions.svelte
@@ -2,15 +2,15 @@
 	import {scale} from 'svelte/transition';
 	import type {Writable} from 'svelte/store';
 
-	export let highscores: Writable<{bestTime: number | null}>;
+	export let highscores: Writable<{time: number | null; applesEaten: number | null}>;
 	export let applesToWin: number;
 </script>
 
 <div class="instructions" transition:scale|local>
 	<div>keyboard controls below</div>
 	<div style:position="relative" style:left="{-15}px">eat {applesToWin} apples to win! asap!!</div>
-	{#if $highscores.bestTime}<div style:position="relative" style:left="{25}px">
-			besst is <strong>{$highscores.bestTime}ms</strong>!
+	{#if $highscores.time}<div style:position="relative" style:left="{25}px">
+			besst is <strong>{$highscores.time}ms</strong>!
 		</div>{/if}
 	<div style:position="relative" style:left="{55}px">don't bite yoursself :]</div>
 </div>

--- a/src/lib/sports/trailsss/ReadyInstructions.svelte
+++ b/src/lib/sports/trailsss/ReadyInstructions.svelte
@@ -2,15 +2,15 @@
 	import {scale} from 'svelte/transition';
 	import type {Writable} from 'svelte/store';
 
-	export let bestTime: Writable<number | null>;
+	export let highscores: Writable<{bestTime: number | null}>;
 	export let applesToWin: number;
 </script>
 
 <div class="instructions" transition:scale|local>
 	<div>keyboard controls below</div>
 	<div style:position="relative" style:left="{-15}px">eat {applesToWin} apples to win! asap!!</div>
-	{#if $bestTime}<div style:position="relative" style:left="{25}px">
-			besst is <strong>{$bestTime}ms</strong>!
+	{#if $highscores.bestTime}<div style:position="relative" style:left="{25}px">
+			besst is <strong>{$highscores.bestTime}ms</strong>!
 		</div>{/if}
 	<div style:position="relative" style:left="{55}px">don't bite yoursself :]</div>
 </div>

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -230,15 +230,17 @@
 		</Gamespace>
 		{#if rendererWidth && autoAspectRatio && aspectRatio}
 			<div class="info">
-				<Ticker {clock} tickDuration={currentTickDuration} {tick} />
-				<EatenOrTimedScores
-					{applesEaten}
-					highestApplesEaten={$highscores.applesEaten}
-					applesToWin={APPLES_EATEN_TO_WIN}
-					{currentTime}
-					bestTime={$highscores.time}
-					{rendererWidth}
-				/>
+				<div class="centered-hz">
+					<Ticker {clock} tickDuration={currentTickDuration} {tick} />
+					<EatenOrTimedScores
+						{applesEaten}
+						highestApplesEaten={$highscores.applesEaten}
+						applesToWin={APPLES_EATEN_TO_WIN}
+						{currentTime}
+						bestTime={$highscores.time}
+						{rendererWidth}
+					/>
+				</div>
 				<StageControls {clock} {tick} {game} />
 				<section class="panel" style:padding="var(--spacing_xl)">
 					<ControlsInstructions />

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -158,7 +158,12 @@
 
 	// TODO hacky, the `game` may be undefined because `toInitialState` is called before `game` is available
 	const spawnApples = (state: SnakeGameState, game: ISnakeGame | undefined): void => {
-		const spawned = spawnRandomTrail(state, game, TRAIL_LENGTH);
+		// TODO was a computed property but we needed it to synchronously update during `game.reset()`
+		const trailLength =
+			applelessTurns === 0
+				? TRAIL_LENGTH
+				: Math.min(TRAIL_LENGTH, APPLES_EATEN_TO_WIN - applesEaten - 1);
+		const spawned = spawnRandomTrail(state, game, trailLength);
 		// As a failsafe, if we can't spawn anything and there's no apples left, end the game.
 		if (!spawned && !state.apples.length) {
 			game?.end('win');

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -64,7 +64,8 @@
 	let applesEaten = 0;
 	let applesEatenStreak = 0;
 	let applelessTurns = 0;
-	const APPLES_EATEN_TO_WIN = 66; // sixxty six applesss
+	// TODO BLOCK revert to 66
+	const APPLES_EATEN_TO_WIN = 3; // sixxty six applesss
 
 	const restart = (): void => {
 		if (!game) return;

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -158,9 +158,7 @@
 
 	// TODO hacky, the `game` may be undefined because `toInitialState` is called before `game` is available
 	const spawnApples = (state: SnakeGameState, game: ISnakeGame | undefined): void => {
-		// TODO was a computed property but we needed it to synchronously update during `game.reset()`
-		const trailLength = Math.min(TRAIL_LENGTH, APPLES_EATEN_TO_WIN - applesEaten - 1);
-		const spawned = spawnRandomTrail(state, game, trailLength);
+		const spawned = spawnRandomTrail(state, game, TRAIL_LENGTH);
 		// As a failsafe, if we can't spawn anything and there's no apples left, end the game.
 		if (!spawned && !state.apples.length) {
 			game?.end('win');

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -127,17 +127,17 @@
 				// TODO maybe an event instead? maybe like classsic,
 				// don't set the high score immediately like this, wait til it's over
 
-				$highscores = {
-					bestTime:
-						!$highscores.bestTime || currentTime <= $highscores.bestTime
-							? Math.round(currentTime)
-							: $highscores.bestTime,
-					applesEaten:
-						applesEaten > APPLES_EATEN_TO_WIN &&
-						(!$highscores.applesEaten || applesEaten >= $highscores.applesEaten)
-							? applesEaten
-							: $highscores.applesEaten,
-				};
+				const time = Math.round(currentTime);
+				if (!$highscores.bestTime || time <= $highscores.bestTime) {
+					$highscores = {...$highscores, bestTime: time};
+				}
+				if (
+					applesEaten > APPLES_EATEN_TO_WIN &&
+					(!$highscores.applesEaten || applesEaten >= $highscores.applesEaten)
+				) {
+					$highscores = {...$highscores, applesEaten};
+				}
+
 				setInStorage(storageKey, $highscores); // TODO enhanced store enables removing this line
 			} else {
 				// The user has played flawlessly, so continue until they make a mistake or run out of tiles.

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -61,11 +61,13 @@
 	let autoAspectRatio: Writable<boolean> | undefined;
 	let aspectRatio: Writable<number> | undefined;
 
+	// TODO BLOCK fix the score when eaten more than target
+
 	let applesEaten = 0;
 	let applesEatenStreak = 0;
 	let applelessTurns = 0;
 	// TODO BLOCK revert to 66
-	const APPLES_EATEN_TO_WIN = 3; // sixxty six applesss
+	const APPLES_EATEN_TO_WIN = 9; // sixxty six applesss
 
 	const restart = (): void => {
 		if (!game) return;
@@ -161,7 +163,7 @@
 		// TODO was a computed property but we needed it to synchronously update during `game.reset()`
 		const trailLength =
 			applelessTurns === 0
-				? TRAIL_LENGTH
+				? Math.min(TRAIL_LENGTH, APPLES_EATEN_TO_WIN)
 				: Math.min(TRAIL_LENGTH, APPLES_EATEN_TO_WIN - applesEaten - 1);
 		const spawned = spawnRandomTrail(state, game, trailLength);
 		// As a failsafe, if we can't spawn anything and there's no apples left, end the game.

--- a/src/lib/sports/trailsss/TrailsssSnake.svelte
+++ b/src/lib/sports/trailsss/TrailsssSnake.svelte
@@ -61,13 +61,10 @@
 	let autoAspectRatio: Writable<boolean> | undefined;
 	let aspectRatio: Writable<number> | undefined;
 
-	// TODO BLOCK fix the score when eaten more than target
-
 	let applesEaten = 0; // maybe should be `currentApplesEaten`, or `currentTime` should be `time`
 	let applesEatenStreak = 0;
 	let applelessTurns = 0;
-	// TODO BLOCK revert to 66
-	const APPLES_EATEN_TO_WIN = 9; // sixxty six applesss
+	const APPLES_EATEN_TO_WIN = 66; // sixxty six applesss
 
 	const restart = (): void => {
 		if (!game) return;

--- a/src/lib/sports/trailsss/WinInstructions.svelte
+++ b/src/lib/sports/trailsss/WinInstructions.svelte
@@ -3,10 +3,15 @@
 	import type {Writable} from 'svelte/store';
 	import RestartInstructions from '$lib/RestartInstructions.svelte';
 
+	export let highscores: Writable<{bestTime: number | null; applesEaten: number | null}>; // TODO don't need to handle `null` here, would need upstream changes
 	export let time: number;
-	export let highscores: Writable<{bestTime: number | null}>; // TODO don't need to handle `null` here, would need upstream changes
+	export let applesEaten: number;
 	export let applesToWin: number;
 	export let restart: () => void;
+
+	$: ateMoreApples = applesEaten > applesToWin;
+	let winType: 'bestTime' | 'applesEaten';
+	$: winType = ateMoreApples ? 'applesEaten' : 'bestTime';
 
 	// TODO doesn't detect if you equal your old score exactly,
 	// but that's super unlikely in most cases (though some games may possibly have "perfect" play)
@@ -15,15 +20,28 @@
 	// but we only care about whole milliseconds for the UX.
 	$: roundedTime = Math.round(time);
 	$: roundedBestTime = $highscores.bestTime === null ? 0 : Math.round($highscores.bestTime);
-	$: newHighScore = roundedTime === roundedBestTime;
+	$: newHighScore =
+		winType === 'bestTime'
+			? roundedTime === roundedBestTime
+			: !$highscores.applesEaten || applesEaten >= $highscores.applesEaten;
 </script>
 
 <div class="instructions" transition:scale|local>
-	<div>you ate all {applesToWin} apples :O</div>
-	<div style:position="relative" style:left="{55}px">in <strong>{roundedTime}ms</strong>!</div>
-	<div style:position="relative" style:left="{25}px">
-		{#if newHighScore}<strong>a new high score!!</strong>{:else}besst is {roundedBestTime}ms!{/if}
-	</div>
+	{#if winType === 'bestTime'}
+		<div>you ate all {applesToWin} apples :O</div>
+		<div style:position="relative" style:left="{55}px">in <strong>{roundedTime}ms</strong>!</div>
+		<div style:position="relative" style:left="{25}px">
+			{#if newHighScore}<strong>a new high score!!</strong>{:else}besst is {roundedBestTime}ms!{/if}
+		</div>
+	{:else if winType === 'applesEaten'}
+		<div>
+			you ate <strong>{applesEaten}</strong> apple{#if applesEaten !== 1}s{/if}
+			{#if applesEaten < 25}:o{:else}:O{/if}
+		</div>
+		<div style:position="relative" style:left="{25}px">
+			{#if newHighScore}<strong>a new high score!!</strong>{:else}besst is {$highscores.applesEaten}!{/if}
+		</div>
+	{/if}
 	<RestartInstructions {restart}>
 		{#if newHighScore}:D{:else}:)){/if}
 	</RestartInstructions>

--- a/src/lib/sports/trailsss/WinInstructions.svelte
+++ b/src/lib/sports/trailsss/WinInstructions.svelte
@@ -4,7 +4,7 @@
 	import RestartInstructions from '$lib/RestartInstructions.svelte';
 
 	export let time: number;
-	export let bestTime: Writable<number | null>; // TODO don't need to handle `null` here, would need upstream changes
+	export let highscores: Writable<{bestTime: number | null}>; // TODO don't need to handle `null` here, would need upstream changes
 	export let applesToWin: number;
 	export let restart: () => void;
 
@@ -14,7 +14,7 @@
 	// These times are in milliseconds with fractional parts,
 	// but we only care about whole milliseconds for the UX.
 	$: roundedTime = Math.round(time);
-	$: roundedBestTime = $bestTime === null ? 0 : Math.round($bestTime);
+	$: roundedBestTime = $highscores.bestTime === null ? 0 : Math.round($highscores.bestTime);
 	$: newHighScore = roundedTime === roundedBestTime;
 </script>
 

--- a/src/lib/sports/trailsss/WinInstructions.svelte
+++ b/src/lib/sports/trailsss/WinInstructions.svelte
@@ -28,7 +28,7 @@
 
 <div class="instructions" transition:scale|local>
 	{#if winType === 'bestTime'}
-		<div>you ate all {applesToWin} apples :O</div>
+		<div>you ate {applesToWin} apples...</div>
 		<div style:position="relative" style:left="{55}px">in <strong>{roundedTime}ms</strong>!</div>
 		<div style:position="relative" style:left="{25}px">
 			{#if newHighScore}<strong>a new high score!!</strong>{:else}besst is {roundedBestTime}ms!{/if}

--- a/src/lib/sports/trailsss/WinInstructions.svelte
+++ b/src/lib/sports/trailsss/WinInstructions.svelte
@@ -3,15 +3,14 @@
 	import type {Writable} from 'svelte/store';
 	import RestartInstructions from '$lib/RestartInstructions.svelte';
 
-	export let highscores: Writable<{bestTime: number | null; applesEaten: number | null}>; // TODO don't need to handle `null` here, would need upstream changes
+	export let highscores: Writable<{time: number | null; applesEaten: number | null}>; // TODO don't need to handle `null` here, would need upstream changes
 	export let time: number;
 	export let applesEaten: number;
 	export let applesToWin: number;
 	export let restart: () => void;
 
-	$: ateMoreApples = applesEaten > applesToWin;
-	let winType: 'bestTime' | 'applesEaten';
-	$: winType = ateMoreApples ? 'applesEaten' : 'bestTime';
+	let winType: 'time' | 'applesEaten';
+	$: winType = applesEaten > applesToWin ? 'applesEaten' : 'time';
 
 	// TODO doesn't detect if you equal your old score exactly,
 	// but that's super unlikely in most cases (though some games may possibly have "perfect" play)
@@ -19,15 +18,15 @@
 	// These times are in milliseconds with fractional parts,
 	// but we only care about whole milliseconds for the UX.
 	$: roundedTime = Math.round(time);
-	$: roundedBestTime = $highscores.bestTime === null ? 0 : Math.round($highscores.bestTime);
+	$: roundedBestTime = $highscores.time === null ? 0 : Math.round($highscores.time);
 	$: newHighScore =
-		winType === 'bestTime'
+		winType === 'time'
 			? roundedTime === roundedBestTime
 			: !$highscores.applesEaten || applesEaten >= $highscores.applesEaten;
 </script>
 
 <div class="instructions" transition:scale|local>
-	{#if winType === 'bestTime'}
+	{#if winType === 'time'}
 		<div>you ate {applesToWin} apples...</div>
 		<div style:position="relative" style:left="{55}px">in <strong>{roundedTime}ms</strong>!</div>
 		<div style:position="relative" style:left="{25}px">

--- a/src/lib/sports/trailsss/WinInstructions.svelte
+++ b/src/lib/sports/trailsss/WinInstructions.svelte
@@ -10,7 +10,7 @@
 	export let restart: () => void;
 
 	let winType: 'time' | 'applesEaten';
-	$: winType = applesEaten > applesToWin ? 'applesEaten' : 'time';
+	$: winType = $highscores.applesEaten || applesEaten > applesToWin ? 'applesEaten' : 'time';
 
 	// TODO doesn't detect if you equal your old score exactly,
 	// but that's super unlikely in most cases (though some games may possibly have "perfect" play)
@@ -21,7 +21,7 @@
 	$: roundedBestTime = $highscores.time === null ? 0 : Math.round($highscores.time);
 	$: newHighScore =
 		winType === 'time'
-			? roundedTime === roundedBestTime
+			? !$highscores.time || roundedTime <= roundedBestTime
 			: !$highscores.applesEaten || applesEaten >= $highscores.applesEaten;
 </script>
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,5 +1,3 @@
-import type {Json} from '@feltcoop/felt/util/json.js';
-
 // TODO maybe refactor to use a storage enhancer function
 
 /**
@@ -9,7 +7,7 @@ import type {Json} from '@feltcoop/felt/util/json.js';
  * @param validate
  * @returns
  */
-export const getFromStorage = <T extends Json>(
+export const getFromStorage = <T>(
 	key: string,
 	validate?: (value: any) => asserts value is T,
 ): T | void => {
@@ -39,7 +37,7 @@ export const getFromStorage = <T extends Json>(
  * @param key
  * @param value
  */
-export const setInStorage = (key: string, value: Json): void => {
+export const setInStorage = (key: string, value: any): void => {
 	try {
 		if (value === undefined) {
 			localStorage.removeItem(key);
@@ -68,6 +66,9 @@ export const askToClearLocalStorage = (key: string): void => {
 	}
 };
 
-export const assertNumber = (value: any): asserts value is number => {
+export function assertNumber(value: unknown): asserts value is number {
 	if (typeof value !== 'number' || Number.isNaN(value)) throw Error();
-};
+}
+export function assertObject(value: any): asserts value is object {
+	if (!value || typeof value !== 'object') throw Error();
+}

--- a/src/lib/updateSnakeGameState.ts
+++ b/src/lib/updateSnakeGameState.ts
@@ -183,6 +183,11 @@ export const spawnRandomTrail = (
 ): boolean => {
 	const apples = toApples(state, game);
 
+	// Cap the apples.
+	if (apples.length > length) {
+		apples.length = length;
+	}
+
 	// Choose a random direction from the last apple.
 	while (apples.length < length) {
 		// Start at the end of the apple trail, or at the head of the snake if no apples.


### PR DESCRIPTION
Fixes #20 

The goal is to improve `trailsss` so that it has a high skill ceiling. After all, this is Svelte Snake *Sports*.

It changes the game so that the highscore is either the time it takes to reach the target count, or if the player does that flawlessly, the total number of apples eaten before a mistake is made. This makes some things more complicated but it's a good usecase for increased highscores complexity.

